### PR TITLE
[WIP] 課題：なぜ 6.35.toFixed(1) == 6.3?

### DIFF
--- a/data_type/to_fixed.html
+++ b/data_type/to_fixed.html
@@ -6,8 +6,8 @@
   <body>
     <script>
       'use strict';
-
       
+      alert( Math.round(6.35 * 10) / 10 );  // 6.4
     </script>
   </body>
 </html>

--- a/data_type/to_fixed.html
+++ b/data_type/to_fixed.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <script>
+      'use strict';
+
+      
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## 概要
Math.round と toFixed は両方とも最も近い数値に丸めます。
0..4 は下がり、5..9 は上がります。
例えは、
```javascript
alert( 1.35.toFixed(1) ); // 1.4
```
下の似た例では、なぜ 6.35 が 6.4 ではなく 6.3 に丸められるのでしょうか？
```javascript
alert( 6.35.toFixed(1) ); // 6.3
```
正しい方法で 6.35 を丸める方法はどうなるでしょう？

