### PR TITLE
[WIP] 課題：border-left-width を borderLeftWidth に変換する

### DIFF
--- a/data_type/border_left_width.html
+++ b/data_type/border_left_width.html
@@ -1,0 +1,26 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <script>
+      'use strict';
+
+      function camelize(str) {
+        let words = str.split('-');
+        let joinWord = [];
+
+        for (let word of words) {
+          if (word != "") {
+            let newWord = word[0].toUpperCase() + word.slice(1);
+
+            joinWord.push(newWord);
+          }
+        }
+
+        return joinWord.join('');
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## 概要
“my-short-string” のようなダッシュ区切りの言葉をキャメルケースの “myShortString” に変更する、
関数 camelize(str) を書いてください。
つまり、すべてのダッシュを削除し、ダッシュの後の各言葉を大文字にします。

```javascript
camelize("background-color") == 'backgroundColor';
camelize("list-style-image") == 'listStyleImage';
camelize("-webkit-transition") == 'WebkitTransition';
```
P.S. ヒント: 文字列を配列に分割するために split を使い、それを変換し、join 結果を返してください。

### タスク
- [x] 文字列を配列に分割する
- [x] 英単語の先頭文字を大文字にする
- [x] 英単語を結合する